### PR TITLE
minor performance boost

### DIFF
--- a/SurfaceUtils.cpp
+++ b/SurfaceUtils.cpp
@@ -142,7 +142,7 @@ bool find_surface_in_region(Surface surfaces[], int n_surfaces, float min_x, flo
 	for (int h = 0; h < n_surfaces; ++h) {
 		bool inside_area = false;
 
-		if (max_y >= surfaces[h].lower_y & min_y <= surfaces[h].upper_y & max_x >= surfaces[h].min_x & min_x <= surfaces[h].max_x & max_z >= surfaces[h].min_z & min_z <= surfaces[h].max_z) {
+		if (max_z >= surfaces[h].min_z &max_y >= surfaces[h].lower_y & min_y <= surfaces[h].upper_y & max_x >= surfaces[h].min_x & min_x <= surfaces[h].max_x &  min_z <= surfaces[h].max_z) {
 			double t_n; double t_d;
 
 			for (int i = 0; i < 3; ++i) {


### PR DESCRIPTION
These condition should be put in the order where the ones to trip most often will be earlier in the set, my testing had this order beating the original one by about 10%, feel free to ignore if you find it doesn't help with the types of searches that are needed more commonly 