### PR TITLE
std::min/max and small optimizations

### DIFF
--- a/PathSearch.cpp
+++ b/PathSearch.cpp
@@ -39,7 +39,7 @@ void output_result(BullyPath &path, float lower_speed, float upper_speed, float 
 bool compare_paths(BullyPath &a, BullyPath &b, int max_frames, float max_offset) {
 	int frame_count = 0;
 
-	int max_i = fmax(a.n_frames, b.n_frames);
+	int max_i = std::max(a.n_frames, b.n_frames);
 
 	float max_offset_squared = max_offset * max_offset;
 

--- a/Surface.cpp
+++ b/Surface.cpp
@@ -1,5 +1,8 @@
 #include "Surface.hpp"
 #include <cmath>
+#include <algorithm>
+
+using std::min, std::max;
 
 void Surface::set_vertices(std::vector<std::vector<float>> &verts) {
 	for (int i = 0; i < 3; ++i) {
@@ -8,13 +11,13 @@ void Surface::set_vertices(std::vector<std::vector<float>> &verts) {
 		}
 	}
 
-	lower_y = fminf(fminf(vertices[0][1], vertices[1][1]), vertices[2][1]) - 5;
-	upper_y = fmaxf(fmaxf(vertices[0][1], vertices[1][1]), vertices[2][1]) + 5;
+	lower_y = min(min(vertices[0][1], vertices[1][1]), vertices[2][1]) - 5;
+	upper_y = max(max(vertices[0][1], vertices[1][1]), vertices[2][1]) + 5;
 
-	min_x = fminf(fminf(vertices[0][0], vertices[1][0]), vertices[2][0]);
-	max_x = fmaxf(fmaxf(vertices[0][0], vertices[1][0]), vertices[2][0]);
-	min_z = fminf(fminf(vertices[0][2], vertices[1][2]), vertices[2][2]);
-	max_z = fmaxf(fmaxf(vertices[0][2], vertices[1][2]), vertices[2][2]);
+	min_x = min(min(vertices[0][0], vertices[1][0]), vertices[2][0]);
+	max_x = max(max(vertices[0][0], vertices[1][0]), vertices[2][0]);
+	min_z = min(min(vertices[0][2], vertices[1][2]), vertices[2][2]);
+	max_z = max(max(vertices[0][2], vertices[1][2]), vertices[2][2]);
 
 	calculate_normal();
 }
@@ -26,13 +29,13 @@ void Surface::set_vertices(VecVec3f &verts) {
 		}
 	}
 
-	lower_y = fminf(fminf(vertices[0][1], vertices[1][1]), vertices[2][1]) - 5;
-	upper_y = fmaxf(fmaxf(vertices[0][1], vertices[1][1]), vertices[2][1]) + 5;
+	lower_y = min(min(vertices[0][1], vertices[1][1]), vertices[2][1]) - 5;
+	upper_y = max(max(vertices[0][1], vertices[1][1]), vertices[2][1]) + 5;
 
-	min_x = fminf(fminf(vertices[0][0], vertices[1][0]), vertices[2][0]);
-	max_x = fmaxf(fmaxf(vertices[0][0], vertices[1][0]), vertices[2][0]);
-	min_z = fminf(fminf(vertices[0][2], vertices[1][2]), vertices[2][2]);
-	max_z = fmaxf(fmaxf(vertices[0][2], vertices[1][2]), vertices[2][2]);
+	min_x = min(min(vertices[0][0], vertices[1][0]), vertices[2][0]);
+	max_x = max(max(vertices[0][0], vertices[1][0]), vertices[2][0]);
+	min_z = min(min(vertices[0][2], vertices[1][2]), vertices[2][2]);
+	max_z = max(max(vertices[0][2], vertices[1][2]), vertices[2][2]);
 
 	calculate_normal();
 }

--- a/vmath.cpp
+++ b/vmath.cpp
@@ -3,10 +3,12 @@
 #include <cmath>
 
 float euclidean_distance(Vec3f &a, Vec3f &b) {
-	return sqrtf(powf(a[0] - b[0], 2.0f) + powf(a[2] - b[2], 2.0f));
+  float dx = a[0] - b[0], dz = a[2] - b[2];
+	return sqrtf(dx * dx + dz * dz);
 }
 float euclidean_distance_squared(Vec3f &a, Vec3f &b) {
-	return powf(a[0] - b[0], 2.0f) + powf(a[2] - b[2], 2.0f);
+  float dx = a[0] - b[0], dz = a[2] - b[2];
+	return dx * dx + dz * dz;
 }
 
 void create_transform_from_normal(Vec3f &normal, Vec3f &position, Mat4 &mat) {


### PR DESCRIPTION
Another large inefficiency. `fminf`/`fmaxf` are used instead of the faster `std::min`/`std::max`.

`fminf` and `fmaxf` will always jump into a subroutine, while `std::min`/`std::max` inline directly to the `minss`/`maxss` instructions.
This does result in some differences handling NaN and signed zero, but that shouldn't matter at all, since we're dealing with non-zero values.

In addition, the `euclidean_distance_squared` and `euclidean_distance` methods are replaced with multiplication, which guarantees that any compiler will not call `powf` during these methods.

Note: `std::min` and `std::max` are equivalent to `(a < b)? a : b` and `(a < b)? b : a`